### PR TITLE
:arrow_up: :books: Add support for mkdocs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -44,3 +44,7 @@ fmt:
 # run pre-commit on all files
 lint:
     python -m nox --session "lint"
+
+# run mkdocs docs locally
+docs:
+    mkdocs serve

--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ See the [Wagtail documentation](https://docs.wagtail.org/en/latest/search.html?q
 `wagtail-heroicons` is licensed under the MIT license. See the [`LICENSE`](LICENSE) file for more information.
 
 Heroicons are licensed under the MIT License and are Copyright (c) 2020 Refactoring UI Inc.
+
+## MkDocs
+
+To preview the MkDocs docs, run:
+
+```bash
+mkdocs serve
+```
+
+Then navigate to `http://localhost:8000/`. There may be formatting issues, because the docs were originally written with the Read the Docs formatting in mind.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: wagtail-heroicons
+repo_name: "williln/wagtail-heroicons"
+repo_url: "https://github.com/williln/wagtail-heroicons"
+
+theme:
+  name: material
+  language: "en"
+
+nav:
+  - Home: "index.md"
+  - Just: "development/just.md"
+  - GitHub Source Code: https://github.com/williln/wagtail-heroicons

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython"
 ]
-dependencies = ["wagtail>=5.2"]
+dependencies = ["wagtail>=5.2", "mkdocs", "mkdocs-material", "mkdocs-monorepo-plugin"]
 description = "Add Heroicons to the Wagtail admin."
 dynamic = ["version"]
 keywords = []


### PR DESCRIPTION
Goal for this PR is to support a proof-of-concept in another repo for pulling multiple repos into one docs deployment

- Adds MkDocs and Material theme 
- [Getting Started - MkDocs](https://www.mkdocs.org/getting-started/#getting-started-with-mkdocs)
- See also: https://github.com/backstage/mkdocs-monorepo-plugin/tree/master 